### PR TITLE
Bug fix for DynamoDBMapper enabling setExclusiveStartKey, setLimit in mapper.query API

### DIFF
--- a/src/main/java/com/amazonaws/services/dynamodb/datamodeling/DynamoDBMapper.java
+++ b/src/main/java/com/amazonaws/services/dynamodb/datamodeling/DynamoDBMapper.java
@@ -1232,6 +1232,8 @@ public class DynamoDBMapper {
         queryRequest.setHashKeyValue(queryExpression.getHashKeyValue());
         queryRequest.setScanIndexForward(queryExpression.isScanIndexForward());
         queryRequest.setRangeKeyCondition(queryExpression.getRangeKeyCondition());
+        queryRequest.setExclusiveStartKey(queryExpression.getExclusiveStartKey());
+        queryRequest.setLimit(queryExpression.getLimit());
 
         return queryRequest;
     }


### PR DESCRIPTION
...yRequestFromExpression allowing full use of DynamoDBQueryExpression in the mapper.query(…) API